### PR TITLE
Add educational tool agents

### DIFF
--- a/src/app/agentConfigs/educationalTool/index.ts
+++ b/src/app/agentConfigs/educationalTool/index.ts
@@ -1,0 +1,12 @@
+import researchAgent from "./researchAgent";
+import teachingAgent from "./teachingAgent";
+import quizAgent from "./quizAgent";
+import { injectTransferTools } from "../utils";
+
+researchAgent.downstreamAgents = [teachingAgent];
+teachingAgent.downstreamAgents = [quizAgent];
+quizAgent.downstreamAgents = [];
+
+const agents = injectTransferTools([researchAgent, teachingAgent, quizAgent]);
+
+export default agents;

--- a/src/app/agentConfigs/educationalTool/quizAgent.ts
+++ b/src/app/agentConfigs/educationalTool/quizAgent.ts
@@ -1,0 +1,20 @@
+import { AgentConfig } from "@/app/types";
+
+const quizAgent: AgentConfig = {
+  name: "quizAgent",
+  publicDescription: "Tests the user's understanding with short questions.",
+  instructions: `
+# Role
+You are the Quiz Agent. After the teaching segment, ask a few brief questions to check the user's comprehension.
+
+# Steps
+1. Politely ask two to three simple questions about the explanation just given.
+2. Give the user a moment to answer. Provide gentle corrections or confirmations as needed.
+3. Offer a short recap or additional clarification if any answers are incorrect.
+4. Finally, thank the user for participating and end the session.
+`,
+  tools: [],
+  downstreamAgents: [],
+};
+
+export default quizAgent;

--- a/src/app/agentConfigs/educationalTool/researchAgent.ts
+++ b/src/app/agentConfigs/educationalTool/researchAgent.ts
@@ -1,0 +1,20 @@
+import { AgentConfig } from "@/app/types";
+import teachingAgent from "./teachingAgent";
+
+const researchAgent: AgentConfig = {
+  name: "researchAgent",
+  publicDescription: "Gathers concise notes on a chosen topic.",
+  instructions: `
+# Role
+You are the Research Agent in a short educational flow. Your job is to gather a few key bullet points about a user-chosen topic.
+
+# Steps
+1. Ask the user which topic they would like to learn about.
+2. Briefly research that topic (you may assume general knowledge) and summarise the most important points in no more than five short bullets.
+3. When finished, politely let the user know you are transferring them to the Teaching Agent for a deeper explanation.
+`,
+  tools: [],
+  downstreamAgents: [teachingAgent],
+};
+
+export default researchAgent;

--- a/src/app/agentConfigs/educationalTool/teachingAgent.ts
+++ b/src/app/agentConfigs/educationalTool/teachingAgent.ts
@@ -1,0 +1,20 @@
+import { AgentConfig } from "@/app/types";
+import quizAgent from "./quizAgent";
+
+const teachingAgent: AgentConfig = {
+  name: "teachingAgent",
+  publicDescription: "Explains a concept clearly and conversationally.",
+  instructions: `
+# Role
+You are the Teaching Agent. You will receive a short summary from the Research Agent and expand on it in a friendly, easy-to-follow way.
+
+# Steps
+1. Introduce yourself and confirm the topic you will be explaining.
+2. Using the notes provided, give a concise explanation of the concept. Keep it clear and use simple language.
+3. When the explanation is finished, tell the user you will hand them over to the Quiz Agent for a quick comprehension check.
+`,
+  tools: [],
+  downstreamAgents: [quizAgent],
+};
+
+export default teachingAgent;

--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -6,6 +6,7 @@ import skynetCredits from "./skynetCredits";
 import frontDeskAuthentication from "./frontDeskAuthentication";
 import customerServiceRetail from "./customerServiceRetail";
 import simpleExample from "./simpleExample";
+import educationalTool from "./educationalTool";
 
 export const allAgentSets: AllAgentConfigsType = {
   comedyBot, 
@@ -15,6 +16,7 @@ export const allAgentSets: AllAgentConfigsType = {
   frontDeskAuthentication,
   customerServiceRetail,
   simpleExample,
+  educationalTool,
 };
 
 export const defaultAgentSetKey = "gardnersAgent";


### PR DESCRIPTION
## Summary
- add new `educationalTool` agent set with Research, Teaching and Quiz agents
- register the new set in the agent index

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495270efa88320bd4a2040d6cfd86c