### PR TITLE
Use assert for EAN test

### DIFF
--- a/test-ean.ts
+++ b/test-ean.ts
@@ -1,5 +1,16 @@
+import assert from 'node:assert/strict';
 import { isValidEan13 } from './src/app/agentConfigs/gardnersAgent/gardnersSalesAgent';
 
-const samples = ['4006381333931','1234567890123','9783161484100', '9780571363611', '9780571366361'];
-console.log('EAN','Valid?');
-samples.forEach(ean => console.log(ean, isValidEan13(ean)));
+const samples: [string, boolean][] = [
+  ['4006381333931', true],
+  ['1234567890123', false],
+  ['9783161484100', true],
+  ['9780571363611', true],
+  ['9780571366361', false]
+];
+
+for (const [ean, expected] of samples) {
+  assert.strictEqual(isValidEan13(ean), expected, `Unexpected validity for ${ean}`);
+}
+
+console.log('All EAN checks passed');


### PR DESCRIPTION
## Summary
- use Node's `assert` in `test-ean.ts`
- check each sample EAN for expected validity

## Testing
- `npm run test:ean` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_6848abb3c51c8320b0dc90cad0ea38cc