### PR TITLE
Fix use client directive

### DIFF
--- a/src/app/components/Transcript.tsx
+++ b/src/app/components/Transcript.tsx
@@ -1,4 +1,4 @@
-"use-client";
+"use client";
 
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";


### PR DESCRIPTION
## Summary
- correct the `use client` directive in `Transcript`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:ean` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848abb11e40832086c2213b49202190