### PR TITLE
Add witness interviewer agent set

### DIFF
--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -7,6 +7,7 @@ import frontDeskAuthentication from "./frontDeskAuthentication";
 import customerServiceRetail from "./customerServiceRetail";
 import simpleExample from "./simpleExample";
 import educationalTool from "./educationalTool";
+import witnessInterviewer from "./witnessInterviewer";
 
 export const allAgentSets: AllAgentConfigsType = {
   comedyBot, 
@@ -17,6 +18,7 @@ export const allAgentSets: AllAgentConfigsType = {
   customerServiceRetail,
   simpleExample,
   educationalTool,
+  witnessInterviewer,
 };
 
 export const defaultAgentSetKey = "gardnersAgent";

--- a/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
@@ -1,0 +1,48 @@
+import { AgentConfig } from "@/app/types";
+import { facts } from "./factTracker";
+
+function contradicts(existing: string, incoming: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
+  const a = norm(existing);
+  const b = norm(incoming);
+  if (a === b) return false;
+  if (a === `not ${b}` || b === `not ${a}`) return true;
+  if (a.startsWith('no ') && a.slice(3) === b) return true;
+  if (b.startsWith('no ') && b.slice(3) === a) return true;
+  return false;
+}
+
+function checkContradictions({ fact }: { fact: string }) {
+  const contradictions = facts.filter((f) => contradicts(f, fact));
+  return { contradictions };
+}
+
+const consistencyChecker: AgentConfig = {
+  name: "consistencyChecker",
+  publicDescription: "Cross-checks new facts against existing ones.",
+  instructions: `
+Compare each new fact with the running list to see if it contradicts any previous statements. Report any contradictions in your reply. Always transfer control back to the interviewer when finished so the witness can be asked to clarify.
+  `,
+  tools: [
+    {
+      type: "function",
+      name: "checkContradictions",
+      description: "Look for contradictions between the new fact and prior facts.",
+      parameters: {
+        type: "object",
+        properties: {
+          fact: { type: "string", description: "The latest fact to check." },
+        },
+        required: ["fact"],
+        additionalProperties: false,
+      },
+    },
+  ],
+  toolLogic: {
+    checkContradictions: async ({ fact }: { fact: string }) =>
+      checkContradictions({ fact }),
+  },
+  downstreamAgents: [{ name: "interviewer", publicDescription: "Continues the interview" }],
+};
+
+export default consistencyChecker;

--- a/src/app/agentConfigs/witnessInterviewer/factTracker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/factTracker.ts
@@ -1,0 +1,42 @@
+import { AgentConfig } from "@/app/types";
+
+let facts: string[] = [];
+
+function addFact({ fact }: { fact: string }) {
+  if (fact) {
+    facts.push(fact);
+  }
+  return { facts };
+}
+
+const factTracker: AgentConfig = {
+  name: "factTracker",
+  publicDescription: "Maintains a running list of facts from the interview.",
+  instructions: `
+You collect and maintain a chronological list of facts and claims mentioned during the interview. When the interviewer transfers to you with new information, log each fact by calling the recordFact tool. After updating the list, transfer control to the consistencyChecker so any contradictions can be flagged.
+  `,
+  tools: [
+    {
+      type: "function",
+      name: "recordFact",
+      description: "Add a fact or claim to the running list.",
+      parameters: {
+        type: "object",
+        properties: {
+          fact: { type: "string", description: "The fact or claim to record." },
+        },
+        required: ["fact"],
+        additionalProperties: false,
+      },
+    },
+  ],
+  toolLogic: {
+    recordFact: async ({ fact }: { fact: string }) => addFact({ fact }),
+  },
+  downstreamAgents: [
+    { name: "consistencyChecker", publicDescription: "Checks for contradictions" },
+  ],
+};
+
+export { facts };
+export default factTracker;

--- a/src/app/agentConfigs/witnessInterviewer/index.ts
+++ b/src/app/agentConfigs/witnessInterviewer/index.ts
@@ -1,0 +1,12 @@
+import interviewer from "./interviewer";
+import factTracker from "./factTracker";
+import consistencyChecker from "./consistencyChecker";
+import { injectTransferTools } from "../utils";
+
+interviewer.downstreamAgents = [factTracker];
+factTracker.downstreamAgents = [consistencyChecker];
+consistencyChecker.downstreamAgents = [interviewer];
+
+const agents = injectTransferTools([interviewer, factTracker, consistencyChecker]);
+
+export default agents;

--- a/src/app/agentConfigs/witnessInterviewer/interviewer.ts
+++ b/src/app/agentConfigs/witnessInterviewer/interviewer.ts
@@ -1,0 +1,13 @@
+import { AgentConfig } from "@/app/types";
+
+const interviewer: AgentConfig = {
+  name: "interviewer",
+  publicDescription: "Voice agent that interviews a witness and gathers details.",
+  instructions: `
+You are a calm and methodical witness interviewer. Open the conversation by briefly explaining that you will ask open questions about an incident. After each answer from the witness, summarise the key details in your own words and politely invite them to expand or clarify. Once you have repeated the details, transfer control to the factTracker agent so the information can be logged and checked for contradictions. Wait for the other agents to transfer you back before continuing the interview. If you are informed of any contradictions, ask the witness to clarify which statement is correct.
+  `,
+  tools: [],
+  downstreamAgents: [{ name: "factTracker", publicDescription: "Tracks facts from the witness" }],
+};
+
+export default interviewer;


### PR DESCRIPTION
## Summary
- create witness interviewer agent set with interviewer, fact tracker and consistency checker
- register new agent set

## Testing
- `npm run test:ean`
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e0c1b65108320b228e4b362b7025a