### PR TITLE
Hide tool call logs

### DIFF
--- a/src/app/contexts/TranscriptContext.tsx
+++ b/src/app/contexts/TranscriptContext.tsx
@@ -8,7 +8,11 @@ type TranscriptContextValue = {
   transcriptItems: TranscriptItem[];
   addTranscriptMessage: (itemId: string, role: "user" | "assistant", text: string, hidden?: boolean) => void;
   updateTranscriptMessage: (itemId: string, text: string, isDelta: boolean) => void;
-  addTranscriptBreadcrumb: (title: string, data?: Record<string, any>) => void;
+  addTranscriptBreadcrumb: (
+    title: string,
+    data?: Record<string, any>,
+    hidden?: boolean
+  ) => void;
   toggleTranscriptItemExpand: (itemId: string) => void;
   updateTranscriptItemStatus: (itemId: string, newStatus: "IN_PROGRESS" | "DONE") => void;
 };
@@ -68,7 +72,11 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
     );
   };
 
-  const addTranscriptBreadcrumb: TranscriptContextValue["addTranscriptBreadcrumb"] = (title, data) => {
+  const addTranscriptBreadcrumb: TranscriptContextValue["addTranscriptBreadcrumb"] = (
+    title,
+    data,
+    hidden = false
+  ) => {
     setTranscriptItems((prev) => [
       ...prev,
       {
@@ -80,7 +88,7 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
         timestamp: newTimestampPretty(),
         createdAtMs: Date.now(),
         status: "DONE",
-        isHidden: false,
+        isHidden: hidden,
       },
     ]);
   };

--- a/src/app/hooks/useHandleServerEvent.ts
+++ b/src/app/hooks/useHandleServerEvent.ts
@@ -70,7 +70,7 @@ export function useHandleServerEvent({
     );
 
     // Add breadcrumb with the final, correctly extracted args object
-    addTranscriptBreadcrumb(`function call: ${functionCallParams.name}`, args);
+    addTranscriptBreadcrumb(`function call: ${functionCallParams.name}`, args, true);
 
     // The rest of the function uses the 'args' object, which should now be correct
     if (currentAgent?.toolLogic?.[functionCallParams.name]) {
@@ -78,7 +78,8 @@ export function useHandleServerEvent({
       const fnResult = await fn(args, transcriptItems);
       addTranscriptBreadcrumb(
         `function call result: ${functionCallParams.name}`,
-        fnResult
+        fnResult,
+        true
       );
 
       // Check if the function result contains a reportFileId and set it
@@ -146,13 +147,15 @@ export function useHandleServerEvent({
       sendClientEvent({ type: "response.create" });
       addTranscriptBreadcrumb(
         `function call: ${functionCallParams.name} response`,
-        functionCallOutput
+        functionCallOutput,
+        true
       );
     } else {
       const simulatedResult = { result: true };
       addTranscriptBreadcrumb(
         `function call fallback: ${functionCallParams.name}`,
-        simulatedResult
+        simulatedResult,
+        true
       );
 
       sendClientEvent({


### PR DESCRIPTION
## Summary
- support hiding transcript breadcrumbs
- hide function call details in conversation transcripts

## Testing
- `npm run test:ean`

------
https://chatgpt.com/codex/tasks/task_e_684e242e8bb48320aa68aa4f37e6258c