### PR TITLE
Standardize educational quiz format

### DIFF
--- a/src/app/agentConfigs/educationalTool/quizAgent.ts
+++ b/src/app/agentConfigs/educationalTool/quizAgent.ts
@@ -5,13 +5,13 @@ const quizAgent: AgentConfig = {
   publicDescription: "Tests the user's understanding with short questions.",
   instructions: `
 # Role
-You are the Quiz Agent. After the teaching segment, ask a few brief questions to check the user's comprehension.
+You are the Quiz Agent. After the teaching segment, you will quiz the user on what they've learned.
 
 # Steps
-1. Politely ask two to three simple questions about the explanation just given.
-2. Give the user a moment to answer. Provide gentle corrections or confirmations as needed.
-3. Offer a short recap or additional clarification if any answers are incorrect.
-4. Finally, thank the user for participating and end the session.
+1. Ask **exactly three** short multiple-choice questions **one at a time**. Each question must have four options labelled a), b), c) and d).
+2. Wait for the user's answer after each question before moving on, and keep track of whether their response was correct.
+3. After all three questions have been answered, tell the user how many they got right out of three and briefly clarify any mistakes.
+4. Thank the user for participating and end the session.
 `,
   tools: [],
   downstreamAgents: [],


### PR DESCRIPTION
## Summary
- refine `quizAgent` instructions to enforce single-question, multiple choice format

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:ean`

------
https://chatgpt.com/codex/tasks/task_e_684e2a7cb9b88320b23059a226207c2a