### PR TITLE
Persist witness facts with MongoDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@types/sqlite3": "^3.1.11",
     "@types/string-similarity": "^4.0.2",
+    "mongodb": "^6.0.0",
     "mssql": "^11.0.1",
     "natural": "^8.0.1",
     "next": "^15.3.1",
@@ -37,5 +38,8 @@
     "tailwindcss": "^3.4.1",
     "ts-node": "^10",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
@@ -1,5 +1,6 @@
 import { AgentConfig } from "@/app/types";
 import { facts } from "./factTracker";
+import { getAllFacts } from "@/app/lib/mongo";
 
 function contradicts(existing: string, incoming: string): boolean {
   const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
@@ -12,8 +13,14 @@ function contradicts(existing: string, incoming: string): boolean {
   return false;
 }
 
-function checkContradictions({ fact }: { fact: string }) {
-  const contradictions = facts.filter((f) => contradicts(f, fact));
+async function checkContradictions({ fact }: { fact: string }) {
+  let allFacts = facts;
+  try {
+    allFacts = await getAllFacts();
+  } catch (err) {
+    console.error("Failed to load facts", err);
+  }
+  const contradictions = allFacts.filter((f) => contradicts(f, fact));
   return { contradictions };
 }
 

--- a/src/app/agentConfigs/witnessInterviewer/factTracker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/factTracker.ts
@@ -1,10 +1,24 @@
 import { AgentConfig } from "@/app/types";
+import { insertFact, getAllFacts } from "@/app/lib/mongo";
 
 let facts: string[] = [];
 
-function addFact({ fact }: { fact: string }) {
+(async () => {
+  try {
+    facts = await getAllFacts();
+  } catch (err) {
+    console.error("Failed to load facts", err);
+  }
+})();
+
+async function addFact({ fact }: { fact: string }) {
   if (fact) {
     facts.push(fact);
+    try {
+      await insertFact(fact);
+    } catch (err) {
+      console.error("Failed to insert fact", err);
+    }
   }
   return { facts };
 }

--- a/src/app/lib/mongo.ts
+++ b/src/app/lib/mongo.ts
@@ -1,0 +1,26 @@
+import { MongoClient, Db } from 'mongodb';
+
+const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/agents';
+
+let client: MongoClient | null = null;
+let db: Db | null = null;
+
+export async function getDb(): Promise<Db> {
+  if (!db) {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db();
+  }
+  return db;
+}
+
+export async function insertFact(fact: string) {
+  const database = await getDb();
+  await database.collection('facts').insertOne({ fact, createdAt: new Date() });
+}
+
+export async function getAllFacts(): Promise<string[]> {
+  const database = await getDb();
+  const records = await database.collection('facts').find().toArray();
+  return records.map((r: any) => r.fact as string);
+}


### PR DESCRIPTION
## Summary
- store witness interview facts in MongoDB
- sync fact list on start from Mongo
- check contradictions using stored facts

## Testing
- `npm run test:ean`

------
https://chatgpt.com/codex/tasks/task_e_684f1e2a3b4c8320b422370113b3f32c