### PR TITLE
Fix witness interviewer fetch base URL

### DIFF
--- a/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/consistencyChecker.ts
@@ -14,7 +14,12 @@ function contradicts(existing: string, incoming: string): boolean {
 
 async function fetchFacts(): Promise<string[]> {
   try {
-    const res = await fetch("/api/facts");
+    const baseUrl =
+      typeof window === "undefined"
+        ? process.env.NEXT_PUBLIC_BASE_URL ||
+          `http://localhost:${process.env.PORT || 3000}`
+        : "";
+    const res = await fetch(`${baseUrl}/api/facts`);
     const data = await res.json();
     if (Array.isArray(data.facts)) {
       return data.facts;

--- a/src/app/agentConfigs/witnessInterviewer/factTracker.ts
+++ b/src/app/agentConfigs/witnessInterviewer/factTracker.ts
@@ -4,7 +4,12 @@ let facts: string[] = [];
 
 (async () => {
   try {
-    const res = await fetch("/api/facts");
+    const baseUrl =
+      typeof window === "undefined"
+        ? process.env.NEXT_PUBLIC_BASE_URL ||
+          `http://localhost:${process.env.PORT || 3000}`
+        : "";
+    const res = await fetch(`${baseUrl}/api/facts`);
     const data = await res.json();
     if (Array.isArray(data.facts)) {
       facts = data.facts;
@@ -18,7 +23,12 @@ async function addFact({ fact }: { fact: string }) {
   if (fact) {
     facts.push(fact);
     try {
-      await fetch("/api/facts", {
+      const baseUrl =
+        typeof window === "undefined"
+          ? process.env.NEXT_PUBLIC_BASE_URL ||
+            `http://localhost:${process.env.PORT || 3000}`
+          : "";
+      await fetch(`${baseUrl}/api/facts`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ fact }),


### PR DESCRIPTION
## Summary
- use absolute base URL when fetching facts on the server for witnessInterviewer agents

## Testing
- `npm run test:ean`

------
https://chatgpt.com/codex/tasks/task_e_684f4d1e68b48320b6dc4720c4796931